### PR TITLE
chore: add include for superset gateway service nginx conf

### DIFF
--- a/roles/dhis2.dhis2/templates/nginx-samesite.dhis.conf.j2
+++ b/roles/dhis2.dhis2/templates/nginx-samesite.dhis.conf.j2
@@ -58,6 +58,7 @@ location /glowroot/ {
 
 include im_instance*;
 include dhis2_instances;
+include dhis2_superset_gateway*;
 
     location / {
         root   /usr/share/nginx/html;


### PR DESCRIPTION
The `*` at the end of the included config name is to prevent nginx config tests from failing if the file doesn't exist.