### PR TITLE
chore: allow deploying newer PostgreSQL versions

### DIFF
--- a/playbooks/vars/postgresql.yml
+++ b/playbooks/vars/postgresql.yml
@@ -1,6 +1,7 @@
 ---
 # vars file for dhis2.dhis2
 postgresql_version: "10"
+postgis_version: "2.5"
 # postgresql_packages:
 #   - postgresql-client-common
 #   - postgresql-{{ postgresql_version }}
@@ -12,7 +13,7 @@ postgresql_packages:
   - postgresql-{{ postgresql_version }}
   - postgresql-contrib
   - libpq-dev
-  - postgresql-{{ postgresql_version }}-postgis-2.5
+  - postgresql-{{ postgresql_version }}-postgis-{{ postgis_version }}
   - postgresql-client-common
 
 postgresql_user: postgres
@@ -30,6 +31,10 @@ postgresql_port_map:
   '11': '5433'
   '12': '5434'
   '13': '5435'
+  '14': '5436'
+  '15': '5437'
+  '16': '5438'
+  '17': '5439'
 postgresql_port: "{{ postgresql_port_map[postgresql_version] }}"
 
 postgresql_config_path: "/etc/postgresql/{{ postgresql_version }}/main"


### PR DESCRIPTION
I'd like to deploy newer PostgreSQL versions on the performance test servers. The newest we support 13 will have its latest release https://www.postgresql.org/support/versioning in a couple of months. 16 is supposed to have some nice additions for monitoring IO.

I tried to deploy pg 16 in awx by applying the changes you see here via the awx job `extra vars`. There seems to be no postgis 2.5 for postgres 16. Looks like postgis 3 is needed which is why I made the change to `postgresql_packages`. `postgresql_port_map` is needed as the job fails otherwise.

I do get this

```sh
"msg": "Unable to start service postgresql@16-main: Assertion failed on job for postgresql@16-main.service.\n",
```

on awx. `postgresql-16` is installed but not `postgresql-16-postgis-3`. Not sure if merging the PR would behave in the same way as when applying these changes via whats currently possible in the awx job 🤷🏻  

Please let me know what I am missing. My change is very likely super naive :joy:
